### PR TITLE
【参考】ページネーション時に元のCakeRequestの変更を防ぐように変更した例

### DIFF
--- a/Event/ExHelperControllerEventListener.php
+++ b/Event/ExHelperControllerEventListener.php
@@ -11,14 +11,14 @@ class ExHelperControllerEventListener extends BcControllerEventListener {
 
 	// 登録先イベントの定義
 	public $events = array(
-		'Blog.Blog.beforeRender',
+		'beforeRender',
 	);
 
 	/**
 	 * 拡張BlogHelperを呼び出しに追加
 	 *
 	 */
-	public function blogBlogBeforeRender(CakeEvent $event) {
+	public function beforeRender(CakeEvent $event) {
 		$path = App::pluginPath('ExHelper');
 
 		// ヘルパーのパスを追加


### PR DESCRIPTION
ExHelperControllerで利用しているCakeRequestが参照渡しになっているので、
元のCakeRequestまでcontrollerやactionのパラメータの変更が及んでいます。
このままだと他のヘルパーの挙動に影響がありそうです。

この副作用を防ごうとしてみたところ、割と面倒なことがわかりました。

※固定ページ内で試したかったのでEventListenerにも若干変更入ってます。
